### PR TITLE
Motor calibration values EEPROM location

### DIFF
--- a/kilolib.c
+++ b/kilolib.c
@@ -16,10 +16,10 @@
 #define EEPROM_IRLOW          (uint8_t*)0x20
 #define EEPROM_IRHIGH         (uint8_t*)0x50
 #define EEPROM_UID            (uint8_t*)0xB0
-#define EEPROM_LEFT_ROTATE    (uint8_t*)0x05
-#define EEPROM_RIGHT_ROTATE   (uint8_t*)0x09
-#define EEPROM_LEFT_STRAIGHT  (uint8_t*)0x0C
-#define EEPROM_RIGHT_STRAIGHT (uint8_t*)0x14
+#define EEPROM_LEFT_ROTATE    (uint8_t*)0x08
+#define EEPROM_RIGHT_ROTATE   (uint8_t*)0x04
+#define EEPROM_LEFT_STRAIGHT  (uint8_t*)0x13
+#define EEPROM_RIGHT_STRAIGHT (uint8_t*)0x0B
 #define TX_MASK_MAX   ((1<<0)|(1<<1)|(1<<2)|(1<<6)|(1<<7))
 #define TX_MASK_MIN   ((1<<0))
 


### PR DESCRIPTION
Hi,

I noticed the motor calibration values are not stored at the same eeprom location as in the original firmware, why is that?

I was surprised to see my motors turn full-speed, and the docs says it's dangerous to run motors full-speed for a long time (fortunately my motors are still alive !)
